### PR TITLE
Using schema abstract

### DIFF
--- a/src/Commands/ListColumnsCommand.php
+++ b/src/Commands/ListColumnsCommand.php
@@ -3,7 +3,7 @@
 namespace OhSeeSoftware\LaravelSchemaList\Commands;
 
 use Illuminate\Console\Command;
-use OhSeeSoftware\LaravelSchemaList\Schemas\SchemaContract;
+use OhSeeSoftware\LaravelSchemaList\Schemas\Schema;
 
 class ListColumnsCommand extends Command
 {
@@ -13,7 +13,7 @@ class ListColumnsCommand extends Command
     /** @var string */
     protected $description = 'Lists the columns in the given table.';
 
-    public function handle(SchemaContract $schema)
+    public function handle(Schema $schema)
     {
         $headers = ['Field', 'Type', 'Nullable', 'Key', 'Default Value', 'Extra'];
         $rows = $schema->getColumns($this->argument('table'));

--- a/src/Commands/ListTablesCommand.php
+++ b/src/Commands/ListTablesCommand.php
@@ -4,7 +4,7 @@ namespace OhSeeSoftware\LaravelSchemaList\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use OhSeeSoftware\LaravelSchemaList\Schemas\SchemaContract;
+use OhSeeSoftware\LaravelSchemaList\Schemas\Schema;
 
 class ListTablesCommand extends Command
 {
@@ -14,7 +14,7 @@ class ListTablesCommand extends Command
     /** @var string */
     protected $description = 'Lists the tables in the default database.';
 
-    public function handle(SchemaContract $schema)
+    public function handle(Schema $schema)
     {
         $headers = ['Tables', 'Columns', 'Rows'];
         $rows = $schema->getTables();

--- a/src/LaravelSchemaListServiceProvider.php
+++ b/src/LaravelSchemaListServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace OhSeeSoftware\LaravelSchemaList;
 
-use Exception;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
@@ -11,7 +10,7 @@ use OhSeeSoftware\LaravelSchemaList\Commands\ListColumnsCommand;
 use OhSeeSoftware\LaravelSchemaList\Commands\ListTablesCommand;
 use OhSeeSoftware\LaravelSchemaList\Schemas\MySQLSchema;
 use OhSeeSoftware\LaravelSchemaList\Schemas\PostgresSchema;
-use OhSeeSoftware\LaravelSchemaList\Schemas\SchemaContract;
+use OhSeeSoftware\LaravelSchemaList\Schemas\Schema;
 use OhSeeSoftware\LaravelSchemaList\Schemas\UnsupportedSchema;
 
 class LaravelSchemaListServiceProvider extends ServiceProvider
@@ -29,14 +28,14 @@ class LaravelSchemaListServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ListTablesCommand::class,
-                ListColumnsCommand::class
+                ListColumnsCommand::class,
             ]);
 
-            $this->app->bind(SchemaContract::class, function () {
+            $this->app->bind(Schema::class, function () {
                 $connection = resolve(ConnectionInterface::class);
                 $connectionClass = get_class($connection);
                 $schema = $this->connections[$connectionClass] ?? UnsupportedSchema::class;
-                
+
                 return new $schema($connection);
             });
         }


### PR DESCRIPTION
This is minor refactor. 

When we use `SchemaContract` we are limited to only the methods in the contract (2 methods) but when we use the abstract `Schema` class we open room for more methods and properties, in this case the commands already have access to the `$connection `property through the `Schema` class.

This still exposes the factory pattern used to build the schema.